### PR TITLE
Use WebSphere Liberty helm chart to deploy twitter notification microservice

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This service expects a **JSON** object in the http body, containing the followin
 
 There is another implementation of this service called *notification-slack*, which posts the message to a **Slack** channel instead.  If both implmentations of the *Notification* service are installed, you could use **Istio** *routing rules* to determine which gets used, and under what conditions.
 
- ### Deploy
+### Deploy
 
 Use WebSphere Liberty helm chart to deploy Twitter Notification microservice:
 ```bash

--- a/README.md
+++ b/README.md
@@ -3,3 +3,17 @@ This service sends a tweet via the *@IBMStockTrader* account on **Twitter**.
 This service expects a **JSON** object in the http body, containing the following fields: *id*, *owner*, *old*, and *new*.  It returns a **JSON** object containing the message sent (or any error message from the attempt) and the location (**Twitter**).
 
 There is another implementation of this service called *notification-slack*, which posts the message to a **Slack** channel instead.  If both implmentations of the *Notification* service are installed, you could use **Istio** *routing rules* to determine which gets used, and under what conditions.
+
+ ### Deploy
+
+Use WebSphere Liberty helm chart to deploy Twitter Notification microservice:
+```bash
+helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+helm install ibm-charts/ibm-websphere-liberty -f <VALUES_YAML> -n <RELEASE_NAME> --tls
+```
+
+In practice this means you'll run something like:
+```bash
+helm repo add ibm-charts https://raw.githubusercontent.com/IBM/charts/master/repo/stable/
+helm install ibm-charts/ibm-websphere-liberty -f manifests/notification-twitter-values.yaml -n notification-twitter --namespace stock-trader --tls
+```

--- a/manifests/notification-twitter-values.yaml
+++ b/manifests/notification-twitter-values.yaml
@@ -1,0 +1,85 @@
+#       Copyright 2017 IBM Corp All Rights Reserved
+
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+
+#       http://www.apache.org/licenses/LICENSE-2.0
+
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+
+###################################################################################################
+## Configuration for deploying Twitter Notification microservice using WebSphere Liberty helm chart
+###################################################################################################
+
+image:
+  repository: ibmstocktrader/notification-twitter   # Docker Hub
+  #repository: mycluster.icp:8500/stock-trader/notification-twitter         # IBM Cloud Private
+  #repository: registry.ng.bluemix.net/stock_trader/notification-twitter    # IBM Container Service
+  tag: latest
+  pullPolicy: Always
+  extraEnvs:
+    - name: TWITTER_CONSUMER_KEY
+      valueFrom:
+        secretKeyRef:
+          name: twitter
+          key: consumerKey
+    - name: TWITTER_CONSUMER_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: twitter
+          key: consumerSecret
+    - name: TWITTER_ACCESS_TOKEN
+      valueFrom:
+        secretKeyRef:
+          name: twitter
+          key: accessToken
+    - name: TWITTER_ACCESS_TOKEN_SECRET
+      valueFrom:
+        secretKeyRef:
+          name: twitter
+          key: accessTokenSecret
+    - name: JWT_AUDIENCE
+      valueFrom:
+        secretKeyRef:
+          name: jwt 
+          key: audience
+    - name: JWT_ISSUER
+      valueFrom:
+        secretKeyRef:
+          name: jwt
+          key: issuer
+
+resourceNameOverride: stock-trader
+
+pod:
+  labels:
+    solution: stock-trader
+    version: twitter
+
+service:
+  enabled: true
+  name: notification-service
+  port: 9443
+  targetPort: 9443
+  type: NodePort
+  extraPorts:
+    - name: notification-service-http
+      protocol: TCP
+      port: 9080
+      targetPort: 9080
+
+ingress:
+  enabled: true 
+  path: "/notification"
+  # annotations:
+    #ingress.kubernetes.io/rewrite-target: /notification
+    #nginx.ingress.kubernetes.io/rewrite-target: /notification
+
+monitoring:
+  enabled: true

--- a/manifests/notification-twitter-values.yaml
+++ b/manifests/notification-twitter-values.yaml
@@ -74,12 +74,5 @@ service:
       port: 9080
       targetPort: 9080
 
-ingress:
-  enabled: true 
-  path: "/notification"
-  # annotations:
-    #ingress.kubernetes.io/rewrite-target: /notification
-    #nginx.ingress.kubernetes.io/rewrite-target: /notification
-
 monitoring:
   enabled: true


### PR DESCRIPTION
- Use WebSphere Liberty helm chart to deploy twitter notification microservice
- Enable Monitoring
- Ingress is not specified